### PR TITLE
Fix compilation bug

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ all: dfuzzer
 makefile.dep:
 	$(CC) -MM *.c >makefile.dep
 $(TARGET): $(OBJ)
-	$(CC) $(CFLAGS) $(OBJ) -o $(TARGET)
+	$(CC) $(OBJ) $(CFLAGS) -o $(TARGET)
 
 doc:
 	doxygen doxyfile


### PR DESCRIPTION
The mainline version didn't compile on Ubuntu but I fixed this by changing the ordering of compiler arguments. The root of the problem was that libraries to link came before object files, which caused the linker to ignore the libraries (as there was nothing to link them to) and then fail on an attempt to link the objects without the libraries (due to unresolved references). With this ordering, everything seems to work fine: we link the object files to the libraries, references are resolved and dfuzzer can start as expected.