### PR TITLE
Logging

### DIFF
--- a/man/dfuzzer.1
+++ b/man/dfuzzer.1
@@ -90,6 +90,12 @@ Enable debug messages. Implies -v. This option should not be normally used
 during testing.
 .RE
 .PP
+\fB\-L\fR \fIDIRNAME\fR
+.RS 4
+Optional directory for full, machine-readable CSV log output. The directory
+must exist.
+.RE
+.PP
 \fB\-s\fR
 .RS 4
 Do not use suppression file. Default behaviour is to use suppression

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -92,7 +92,6 @@ int main(int argc, char **argv)
 	int bus_skip = 0;			// if skipping one of buses or both, set to 1
 	int i;
 	char log_file_name[MAXLEN];
-	char log_file_err[MAXLEN];
 
 
 	df_parse_parameters(argc, argv);
@@ -101,17 +100,17 @@ int main(int argc, char **argv)
 	if (df_full_log_flag) {
 		size_t len = strlen(log_dir_name);
 		strcpy(log_file_name, log_dir_name);
-		log_file_name[len++] = '/';
-		log_file_name[len]   = 0;
-		strncat(log_file_name, target_proc.name, MAXLEN-len);
-		logfile = fopen(log_file_name, "a+");
+		if (len <= MAXLEN-2) {
+			log_file_name[len++] = '/';
+			log_file_name[len]   = 0;
+			strncat(log_file_name, target_proc.name, MAXLEN-len-1);
+			logfile = fopen(log_file_name, "a+");
+		}
 		if(!logfile) {
-			snprintf(log_file_err, MAXLEN, "Error opening file %s; detailed logs will not be written\n",
-				 log_file_name);
-			df_error(log_file_err, NULL);
+			df_fail("Error opening file %s; detailed logs will not be written\n",
+				log_file_name);
 			df_full_log_flag = 0;
 		}
-
 	}
 	if (!df_supflg) {		// if -s option was not passed
 		if (df_load_suppressions() == -1) {

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 		strncat(log_file_name, target_proc.name, MAXLEN-len);
 		logfile = fopen(log_file_name, "a+");
 		if(!logfile) {
-			snprintf(log_file_err, NAXLEN, "Error opening file %s; detailed logs will not be written\n",
+			snprintf(log_file_err, MAXLEN, "Error opening file %s; detailed logs will not be written\n",
 				 log_file_name);
 			df_error(log_file_err, NULL);
 			df_full_log_flag = 0;

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -66,7 +66,7 @@ static int df_supflg;
 	If command/script returns >0, dfuzzer prints fail message,
 	if 0 it continues */
 static char *df_execute_cmd;
-/** If -l is passed, full log of method calls and their return values will be
+/** If -L is passed, full log of method calls and their return values will be
     written to a [BUS_NAME.log] file */
 static int df_full_log_flag;
 /** Pointer to a file for full logging  */

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -69,6 +69,9 @@ static char *df_execute_cmd;
 /** If -l is passed, full log of method calls and their return values will be
     written to a [BUS_NAME.log] file */
 static int df_full_log_flag;
+/** Pointer to a file for full logging  */
+FILE* logfile;
+
 
 /**
  * @function Main function controls fuzzing.
@@ -86,11 +89,22 @@ int main(int argc, char **argv)
 	int rsys = 0;				// return value from system bus testing
 	int bus_skip = 0;			// if skipping one of buses or both, set to 1
 	int i;
+	char log_file_name[MAXLEN];
 
 
 	df_parse_parameters(argc, argv);
 
 
+	if (df_full_log_flag) {
+		strcpy(log_file_name, "logs/");
+		strncat(log_file_name, target_proc.name, MAXLEN-6);
+		logfile = fopen(log_file_name, "a+");
+		if(!logfile) {
+			printf("Error opening file %s; detailed logs will not be written\n", log_file_name);
+			df_full_log_flag = 0;
+		}
+
+	}
 	if (!df_supflg) {		// if -s option was not passed
 		if (df_load_suppressions() == -1) {
 			// free all memory
@@ -1149,6 +1163,7 @@ void df_parse_parameters(int argc, char **argv)
 			break;
 		case 'L':
 			df_full_log_flag = 1;
+			break;
 		default:	// '?'
 			exit(1);
 			break;
@@ -1342,7 +1357,7 @@ void df_print_help(const char *name)
 	"   Enable debug messages. Implies -v. This option should not be normally\n"
 	"   used during testing.\n"
 	"-L\n"
-	"   Write full, parseable log to a BUS_NAME.log file.\n"
+	"   Write full, parseable log to a logs/BUS_NAME file.\n"
 	"-s\n"
 	"   Do not use suppression file. Default behaviour is to use suppression\n"
 	"   files in this order (if one doesn't exist next in order is taken\n"

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -66,7 +66,9 @@ static int df_supflg;
 	If command/script returns >0, dfuzzer prints fail message,
 	if 0 it continues */
 static char *df_execute_cmd;
-
+/** If -l is passed, full log of method calls and their return values will be
+    written to a [BUS_NAME.log] file */
+static int df_full_log_flag;
 
 /**
  * @function Main function controls fuzzing.
@@ -1043,7 +1045,7 @@ void df_parse_parameters(int argc, char **argv)
 	int c = 0;
 	int nflg = 0, oflg = 0, iflg = 0, mflg = 0, bflg = 0, tflg = 0, eflg = 0;
 
-	while ((c = getopt(argc, argv, "n:o:i:m:b:t:e:sdvlhV")) != -1) {
+	while ((c = getopt(argc, argv, "n:o:i:m:b:t:e:sdvlhVL")) != -1) {
 		switch (c) {
 		case 'n':
 			if (nflg != 0) {
@@ -1145,6 +1147,8 @@ void df_parse_parameters(int argc, char **argv)
 			df_print_help(argv[0]);
 			exit(0);
 			break;
+		case 'L':
+			df_full_log_flag = 1;
 		default:	// '?'
 			exit(1);
 			break;
@@ -1337,6 +1341,8 @@ void df_print_help(const char *name)
 	"-d\n"
 	"   Enable debug messages. Implies -v. This option should not be normally\n"
 	"   used during testing.\n"
+	"-L\n"
+	"   Write full, parseable log to a BUS_NAME.log file.\n"
 	"-s\n"
 	"   Do not use suppression file. Default behaviour is to use suppression\n"
 	"   files in this order (if one doesn't exist next in order is taken\n"

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -92,6 +92,7 @@ int main(int argc, char **argv)
 	int bus_skip = 0;			// if skipping one of buses or both, set to 1
 	int i;
 	char log_file_name[MAXLEN];
+	char log_file_err[MAXLEN];
 
 
 	df_parse_parameters(argc, argv);
@@ -105,7 +106,9 @@ int main(int argc, char **argv)
 		strncat(log_file_name, target_proc.name, MAXLEN-len);
 		logfile = fopen(log_file_name, "a+");
 		if(!logfile) {
-			printf("Error opening file %s; detailed logs will not be written\n", log_file_name);
+			snprintf(log_file_err, NAXLEN, "Error opening file %s; detailed logs will not be written\n",
+				 log_file_name);
+			df_error(log_file_err, NULL);
 			df_full_log_flag = 0;
 		}
 

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -1378,7 +1378,7 @@ void df_print_help(const char *name)
 	"   Enable debug messages. Implies -v. This option should not be normally\n"
 	"   used during testing.\n"
 	"-L DIRNAME\n"
-	"   Write full, parseable log to a DIRNAME/BUS_NAME file.\n"
+	"   Write full, parseable log to a DIRNAME/BUS_NAME file. The directory must exist.\n"
 	"-s\n"
 	"   Do not use suppression file. Default behaviour is to use suppression\n"
 	"   files in this order (if one doesn't exist next in order is taken\n"

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -398,7 +398,7 @@ static int df_fuzz_write_log(void)
 				if (tmp9 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp9);
 				while((tmp9 != NULL) && (*tmp9)){
-					FULL_LOG("%x ", *tmp9++ & 0xff);
+					FULL_LOG("%02x", *tmp9++ & 0xff);
 				}
 				FULL_LOG(";");
 				free(tmp9cpy);
@@ -412,7 +412,7 @@ static int df_fuzz_write_log(void)
 				if (tmp10 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp10);
 				while((tmp10 != NULL) && (*tmp10)){
-					FULL_LOG("%x", *tmp10++ & 0xff);
+					FULL_LOG("%02x", *tmp10++ & 0xff);
 				}
 				FULL_LOG(";");
 				free(tmp10cpy);
@@ -426,7 +426,7 @@ static int df_fuzz_write_log(void)
 				if (tmp11 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp11);
 				while((tmp11 != NULL) && (*tmp11)){
-					FULL_LOG("%x", *tmp11++ & 0xff);
+					FULL_LOG("%02x", *tmp11++ & 0xff);
 				}
 				FULL_LOG(";");
 				free(tmp11cpy);
@@ -444,7 +444,7 @@ static int df_fuzz_write_log(void)
 					if (tmp12 != NULL)
 						df_fail(" [length: %d B]-- '%s'\n", str_len, tmp12);
 					while((tmp12 != NULL) && (*tmp12)){
-						FULL_LOG("%x", *tmp12++ & 0xff);
+						FULL_LOG("%02x", *tmp12++ & 0xff);
 					}
 					free(tmp12cpy);
 				} else {

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -706,11 +706,11 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
 		prev_memory = used_memory;
 
 
+		if(logfile) df_fuzz_write_log();
 		if (value != NULL) {
 			g_variant_unref(value);
 			value = NULL;
 		}
-		if(logfile) df_fuzz_write_log();
 		if (df_except_counter == MAX_EXCEPTIONS) {
 			df_except_counter = 0;
 			break;

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -398,7 +398,7 @@ static int df_fuzz_write_log(void)
 				if (tmp9 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp9);
 				while((tmp9 != NULL) & (*tmp9)){
-					FULL_LOG("%x", *tmp9++ & 0xff);
+					FULL_LOG("%x ", *tmp9++ & 0xff);
 				}
 				FULL_LOG(";");
 				free(tmp9cpy);

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -397,7 +397,7 @@ static int df_fuzz_write_log(void)
 				tmp9cpy = tmp9;
 				if (tmp9 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp9);
-				while((tmp9 != NULL) & (*tmp9)){
+				while((tmp9 != NULL) && (*tmp9)){
 					FULL_LOG("%x ", *tmp9++ & 0xff);
 				}
 				FULL_LOG(";");
@@ -411,7 +411,7 @@ static int df_fuzz_write_log(void)
 				tmp10cpy = tmp10;
 				if (tmp10 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp10);
-				while((tmp10 != NULL) & (*tmp10)){
+				while((tmp10 != NULL) && (*tmp10)){
 					FULL_LOG("%x", *tmp10++ & 0xff);
 				}
 				FULL_LOG(";");
@@ -425,7 +425,7 @@ static int df_fuzz_write_log(void)
 				tmp11cpy = tmp11;
 				if (tmp11 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp11);
-				while((tmp11 != NULL) & (*tmp11)){
+				while((tmp11 != NULL) && (*tmp11)){
 					FULL_LOG("%x", *tmp11++ & 0xff);
 				}
 				FULL_LOG(";");

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -446,7 +446,6 @@ static int df_fuzz_write_log(void)
 					while((tmp12 != NULL) && (*tmp12)){
 						FULL_LOG("%x", *tmp12++ & 0xff);
 					}
-					FULL_LOG("\n");
 					free(tmp12cpy);
 				} else {
 					df_fail("-- 'unable to deconstruct GVariant instance'\n");
@@ -461,18 +460,15 @@ static int df_fuzz_write_log(void)
 				break;
 			default:
 				df_fail("Unknown argument signature '%s'\n", s->sig);
-				FULL_LOG("\n");
 				return -1;
 			}
 		} else {	// advanced argument (array of something, dictionary, ...)
 			df_debug("Not yet implemented in df_fuzz_write_log()\n");
-			FULL_LOG("\n");
 			return 0;
 		}
 
 		s = s->next;
 	}
-	FULL_LOG("\n");
 
 	return 0;
 }
@@ -722,6 +718,7 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
 	if (leaking_mem_flg)	// warning
 		return 3;
 	df_verbose("\r  \e[32mPASS\e[0m %s\n", df_list.df_method_name);
+	FULL_LOG("Success\n");
 	return 0;
 
 
@@ -744,10 +741,15 @@ fail_label:
 		df_fail(" -e '%s'", execute_cmd);
 	df_fail("\e[0m\n");
 
-	if (ret == 1)		// method returning void is returning illegal value
+	if (ret == 1){	// method returning void is returning illegal value
+		FULL_LOG("Illegal retval\n");
 		return 2;
-	if (execr > 0)		// command/script execution ended with error
+	}
+	if (execr > 0){	// command/script execution ended with error
+		FULL_LOG("Command execution error\n");
 		return 4;
+	}
+	FULL_LOG("Crash\n");
 	return 1;
 
 

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -311,15 +311,19 @@ static int df_fuzz_write_log(void)
 	struct df_signature *s = df_list.list;	// pointer on first signature
 	int len = 0;
 	int str_len = 0;
+	
+	FULL_LOG("%s;", df_list.df_method_name);
 
 	while (s != NULL) {
 		len = strlen(s->sig);
 		if (len <= 0) {
 			df_fail("No argument signature\n");
+			FULL_LOG("\n");
 			return -1;
 		} else if (len == 1) {	// one character argument
 			df_fail("    --");
 			df_fail("%s", s->sig);
+			FULL_LOG("%s;", s->sig);
 
 			switch (s->sig[0]) {
 			case 'y':
@@ -327,94 +331,123 @@ static int df_fuzz_write_log(void)
 				guint8 tmp;
 				g_variant_get(s->var, s->sig, &tmp);
 				df_fail("-- '%u'\n", tmp);
+				FULL_LOG("%u;", tmp);
 				break;
 			case 'b':
 				;
 				gboolean tmp1;
 				g_variant_get(s->var, s->sig, &tmp1);
 				df_fail("-- '%s'\n", ((tmp1 == 1) ? "true" : "false"));
+				FULL_LOG("%s", tmp1 ? "true" : "false");
 				break;
 			case 'n':
 				;
 				gint16 tmp2;
 				g_variant_get(s->var, s->sig, &tmp2);
 				df_fail("-- '%d'\n", tmp2);
+				FULL_LOG("%d;", tmp2);
 				break;
 			case 'q':
 				;
 				guint16 tmp3;
 				g_variant_get(s->var, s->sig, &tmp3);
 				df_fail("-- '%u'\n", tmp3);
+				FULL_LOG("%u;", tmp3);
 				break;
 			case 'i':
 				;
 				gint32 tmp4;
 				g_variant_get(s->var, s->sig, &tmp4);
 				df_fail("-- '%d'\n", tmp4);
+				FULL_LOG("%d;", tmp4);
 				break;
 			case 'u':
 				;
 				guint32 tmp5;
 				g_variant_get(s->var, s->sig, &tmp5);
 				df_fail("-- '%u'\n", tmp5);
+				FULL_LOG("%u;", tmp5);
 				break;
 			case 'x':
 				;
 				gint64 tmp6;
 				g_variant_get(s->var, s->sig, &tmp6);
 				df_fail("-- '%ld'\n", tmp6);
+				FULL_LOG("%ld;", tmp6);
 				break;
 			case 't':
 				;
 				guint64 tmp7;
 				g_variant_get(s->var, s->sig, &tmp7);
 				df_fail("-- '%lu'\n", tmp7);
+				FULL_LOG("%lu;", tmp7);
 				break;
 			case 'd':
 				;
 				gdouble tmp8;
 				g_variant_get(s->var, s->sig, &tmp8);
 				df_fail("-- '%lg'\n", tmp8);
+				FULL_LOG("%lg;", tmp8);
 				break;
 			case 's':
 				;
-				gchar *tmp9 = NULL;
+				gchar *tmp9 = NULL, *tmp9cpy = NULL;
 				g_variant_get(s->var, s->sig, &tmp9);
 				str_len = strlen(tmp9);
+				tmp9cpy = tmp9;
 				if (tmp9 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp9);
-				free(tmp9);
+				while((tmp9 != NULL) & (*tmp9)){
+					FULL_LOG("%x", *tmp9++ & 0xff);
+				}
+				FULL_LOG(";");
+				free(tmp9cpy);
 				break;
 			case 'o':
 				;
-				gchar *tmp10 = NULL;
+				gchar *tmp10 = NULL, *tmp10cpy = NULL;
 				g_variant_get(s->var, s->sig, &tmp10);
 				str_len = strlen(tmp10);
+				tmp10cpy = tmp10;
 				if (tmp10 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp10);
-				free(tmp10);
+				while((tmp10 != NULL) & (*tmp10)){
+					FULL_LOG("%x", *tmp10++ & 0xff);
+				}
+				FULL_LOG(";");
+				free(tmp10cpy);
 				break;
 			case 'g':
 				;
-				gchar *tmp11 = NULL;
+				gchar *tmp11 = NULL, *tmp11cpy;
 				g_variant_get(s->var, s->sig, &tmp11);
 				str_len = strlen(tmp11);
+				tmp11cpy = tmp11;
 				if (tmp11 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp11);
-				free(tmp11);
+				while((tmp11 != NULL) & (*tmp11)){
+					FULL_LOG("%x", *tmp11++ & 0xff);
+				}
+				FULL_LOG(";");
+				free(tmp11cpy);
 				break;
 			case 'v':
 				;
 				GVariant *var = NULL;
-				gchar *tmp12 = NULL;
+				gchar *tmp12 = NULL, *tmp12cpy = NULL;
 				g_variant_get(s->var, s->sig, var);
 				if (var != NULL &&
 					g_variant_check_format_string(var, "s", FALSE)) {
 					g_variant_get(&var, "s", &tmp12);
 					str_len = strlen(tmp12);
+					tmp12cpy = tmp12;
 					if (tmp12 != NULL)
 						df_fail(" [length: %d B]-- '%s'\n", str_len, tmp12);
-					free(tmp12);
+					while((tmp12 != NULL) && (*tmp12)){
+						FULL_LOG("%x", *tmp12++ & 0xff);
+					}
+					FULL_LOG("\n");
+					free(tmp12cpy);
 				} else {
 					df_fail("-- 'unable to deconstruct GVariant instance'\n");
 				}
@@ -423,19 +456,23 @@ static int df_fuzz_write_log(void)
 				;
 				gint32 tmp13;
 				g_variant_get(s->var, s->sig, &tmp13);
+				FULL_LOG("%d;", tmp13);
 				df_fail("-- '%d'\n", tmp13);
 				break;
 			default:
 				df_fail("Unknown argument signature '%s'\n", s->sig);
+				FULL_LOG("\n");
 				return -1;
 			}
 		} else {	// advanced argument (array of something, dictionary, ...)
 			df_debug("Not yet implemented in df_fuzz_write_log()\n");
+			FULL_LOG("\n");
 			return 0;
 		}
 
 		s = s->next;
 	}
+	FULL_LOG("\n");
 
 	return 0;
 }
@@ -673,6 +710,7 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
 			g_variant_unref(value);
 			value = NULL;
 		}
+		if(logfile) df_fuzz_write_log();
 		if (df_except_counter == MAX_EXCEPTIONS) {
 			df_except_counter = 0;
 			break;
@@ -691,13 +729,13 @@ fail_label:
 	df_mem_limit = -1;		// set to -1 to reload memory limit
 	if (ret != 1) {
 		df_fail("   on input:\n");
-		df_fuzz_write_log();
 	}
 	if (value != NULL)
 		g_variant_unref(value);
 
 	df_fail("   reproducer: \e[33mdfuzzer -v -n %s -o %s -i %s"
 			" -t %s", name, obj, intf, df_list.df_method_name);
+	df_fuzz_write_log();
 	if (df_mlflg)
 		df_fail(" -m %ld", df_mem_limit);
 	if (buf_size_flg)

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -726,8 +726,8 @@ fail_label:
 	df_mem_limit = -1;		// set to -1 to reload memory limit
 	if (ret != 1) {
 		df_fail("   on input:\n");
+		df_fuzz_write_log();
 	}
-	df_fuzz_write_log();
 	if (value != NULL)
 		g_variant_unref(value);
 
@@ -742,7 +742,6 @@ fail_label:
 	df_fail("\e[0m\n");
 
 	if (ret == 1){	// method returning void is returning illegal value
-		FULL_LOG("Illegal retval\n");
 		return 2;
 	}
 	if (execr > 0){	// command/script execution ended with error

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -703,6 +703,7 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
 
 
 		if(logfile) df_fuzz_write_log();
+		FULL_LOG("Success\n");
 		if (value != NULL) {
 			g_variant_unref(value);
 			value = NULL;
@@ -718,7 +719,6 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
 	if (leaking_mem_flg)	// warning
 		return 3;
 	df_verbose("\r  \e[32mPASS\e[0m %s\n", df_list.df_method_name);
-	FULL_LOG("Success\n");
 	return 0;
 
 

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -727,12 +727,12 @@ fail_label:
 	if (ret != 1) {
 		df_fail("   on input:\n");
 	}
+	df_fuzz_write_log();
 	if (value != NULL)
 		g_variant_unref(value);
 
 	df_fail("   reproducer: \e[33mdfuzzer -v -n %s -o %s -i %s"
 			" -t %s", name, obj, intf, df_list.df_method_name);
-	df_fuzz_write_log();
 	if (df_mlflg)
 		df_fail(" -m %ld", df_mem_limit);
 	if (buf_size_flg)

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -397,8 +397,10 @@ static int df_fuzz_write_log(void)
 				tmp9cpy = tmp9;
 				if (tmp9 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp9);
-				while((tmp9 != NULL) && (*tmp9)){
-					FULL_LOG("%02x", *tmp9++ & 0xff);
+				if (logfile) {
+					while((tmp9 != NULL) && (*tmp9)){
+						FULL_LOG("%02x", *tmp9++ & 0xff);
+					}
 				}
 				FULL_LOG(";");
 				free(tmp9cpy);
@@ -411,8 +413,10 @@ static int df_fuzz_write_log(void)
 				tmp10cpy = tmp10;
 				if (tmp10 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp10);
-				while((tmp10 != NULL) && (*tmp10)){
-					FULL_LOG("%02x", *tmp10++ & 0xff);
+				if (logfile) {
+					while((tmp10 != NULL) && (*tmp10)){
+						FULL_LOG("%02x", *tmp10++ & 0xff);
+					}
 				}
 				FULL_LOG(";");
 				free(tmp10cpy);
@@ -425,8 +429,10 @@ static int df_fuzz_write_log(void)
 				tmp11cpy = tmp11;
 				if (tmp11 != NULL)
 					df_fail(" [length: %d B]-- '%s'\n", str_len, tmp11);
-				while((tmp11 != NULL) && (*tmp11)){
-					FULL_LOG("%02x", *tmp11++ & 0xff);
+				if (logfile) {
+					while((tmp11 != NULL) && (*tmp11)){
+						FULL_LOG("%02x", *tmp11++ & 0xff);
+					}
 				}
 				FULL_LOG(";");
 				free(tmp11cpy);
@@ -443,9 +449,12 @@ static int df_fuzz_write_log(void)
 					tmp12cpy = tmp12;
 					if (tmp12 != NULL)
 						df_fail(" [length: %d B]-- '%s'\n", str_len, tmp12);
-					while((tmp12 != NULL) && (*tmp12)){
-						FULL_LOG("%02x", *tmp12++ & 0xff);
+					if (logfile) {
+						while((tmp12 != NULL) && (*tmp12)){
+							FULL_LOG("%02x", *tmp12++ & 0xff);
+						}
 					}
+					FULL_LOG(";");
 					free(tmp12cpy);
 				} else {
 					df_fail("-- 'unable to deconstruct GVariant instance'\n");

--- a/src/fuzz.h
+++ b/src/fuzz.h
@@ -137,6 +137,9 @@ void df_fuzz_clean_method(void);
 
 extern FILE* logfile;
 
+/** Writes a message to a logfile if it is opened (i.e. if -L flag was passed
+ * when running dfuzzer.
+ */
 #define FULL_LOG(fmt, ...) if(logfile) fprintf(logfile, fmt, ##__VA_ARGS__)
 
 #endif

--- a/src/fuzz.h
+++ b/src/fuzz.h
@@ -135,4 +135,8 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
  */
 void df_fuzz_clean_method(void);
 
+extern FILE* logfile;
+
+#define FULL_LOG(fmt, ...) if(logfile) fprintf(logfile, fmt, ##__VA_ARGS__)
+
 #endif


### PR DESCRIPTION
This adds a -L command line switch, which works like this:
- a file logs/[BUS_NAME] is created if it doesn't exist
- if such file exists, new logs will be appended to it
- with each method call, a new CSV line is written, with a structure like this:
``` method name; argument-0 type; argument-0 value; (...) ; argument-n type; argument-n value; Success/Crash/Illegal retval/Command execution error```
- strings are represented as space-separated sequences of hexadecimal digits

This allows a more machine-readable way of dealing with logs, e.g. to automatically create crash reproduction scripts in a language of choice (e.g. sh with dbus-send or C with GDBus - I think I'll write such a generator soon).

A thing I'd like to add in the future would be differentiation between method calls that return and those that throw (they're both treated as 'Success', but I'd like to separate them because it would make it easier to check for methods which should check for permissions but don't), and maybe to log the exact return value (as it might be useful if it discloses something it shouldn't).

Currently, this patch makes otuput to stdout overly verbose as it outputs each method call as if it was a crash. We could avoid this by adding another argument to df_fuzz_write_log() (or a global boolean) that would tell us whether we want to output to stdout or not, but given that this mode is meant more for machine-readability than human readability, we can just pipe everything to /dev/null:
``` ./dfuzzer -Ln BUS_NAME > /dev/null 2>&1 ```