### PR TITLE
Reproducer generator

### DIFF
--- a/scripts/reprogen.py
+++ b/scripts/reprogen.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+import argparse

--- a/scripts/reprogen.py
+++ b/scripts/reprogen.py
@@ -40,7 +40,10 @@ def dbus_send(bus, name, iface, obj, method, args):
 
 def gdbus_format(args):
     ret = ""
+    print(args, file=sys.stderr)
     for arg in args:
+        if arg[0] == '/':
+            continue
         if arg[0] in 'sogv':
             ret += '"`echo {} | xxd -r -p`" '.format(arg[1])
         else:

--- a/scripts/reprogen.py
+++ b/scripts/reprogen.py
@@ -38,6 +38,13 @@ def dbus_send(bus, name, iface, obj, method, args):
     print("dbus-send --{} --dest={} --print-reply {} {}.{} {}"
             .format(bus, name, obj, iface, method, dbus_send_format(args)))
 
+def gdbus_format(args):
+    return ""
+
+def gdbus(bus, name, iface, obj, method, args):
+    print("gdbus call --{} --dest {} --object-path {} --method {}.{} {}"
+            .format(bus, name, obj, iface, method, gdbu_format(args)))
+
 def main(bus, process, name_for_stdin, results_filter, files):
     if name_for_stdin is None and '-' in files:
         return False

--- a/scripts/reprogen.py
+++ b/scripts/reprogen.py
@@ -39,11 +39,17 @@ def dbus_send(bus, name, iface, obj, method, args):
             .format(bus, name, obj, iface, method, dbus_send_format(args)))
 
 def gdbus_format(args):
-    return ""
+    ret = ""
+    for arg in args:
+        if arg[0] in 'sogv':
+            ret += '"`echo {} | xxd -r -p`" '.format(arg[1])
+        else:
+            ret += "{} ".format(arg[1])
+    return ret
 
 def gdbus(bus, name, iface, obj, method, args):
     print("gdbus call --{} --dest {} --object-path {} --method {}.{} {}"
-            .format(bus, name, obj, iface, method, gdbu_format(args)))
+            .format(bus, name, obj, iface, method, gdbus_format(args)))
 
 def main(bus, process, name_for_stdin, results_filter, files):
     if name_for_stdin is None and '-' in files:
@@ -59,13 +65,13 @@ def main(bus, process, name_for_stdin, results_filter, files):
     return True
 
 if __name__ == '__main__':
-    functions = {'dbus-send': dbus_send}
+    functions = {'dbus-send': dbus_send, 'gdbus': gdbus}
     p = argparse.ArgumentParser(
             description='Generate reproduction code from dfuzzer logs')
     g = p.add_mutually_exclusive_group(required=True)
     g.add_argument('--system',  action='store_true', help='Use system bus')
     g.add_argument('--session', action='store_true', help='Use session bus')
-    p.add_argument('-t', '--target', choices=['dbus-send'],
+    p.add_argument('-t', '--target', choices=['dbus-send', 'gdbus'],
             default='dbus-send', help='Target language/library')
     p.add_argument('-n', '--name', type=str, default=None,
             help='Name of the bus to use when taking input from stdin')

--- a/scripts/reprogen.py
+++ b/scripts/reprogen.py
@@ -87,7 +87,9 @@ if __name__ == '__main__':
     g = p.add_mutually_exclusive_group(required=True)
     g.add_argument('--system',  action='store_true', help='Use system bus')
     g.add_argument('--session', action='store_true', help='Use session bus')
-    p.add_argument('-t', '--target', choices=['dbus-send', 'gdbus'],
+    # gdbus is temporarily disabled due to bugs (it seems to treat arguments
+    # as XML instead of raw string, and throws errors when it's not valid)
+    p.add_argument('-t', '--target', choices=['dbus-send'],
             default='dbus-send', help='Target language/library')
     p.add_argument('-n', '--name', type=str, default=None,
             help='Name of the bus to use when taking input from stdin')

--- a/scripts/reprogen.py
+++ b/scripts/reprogen.py
@@ -77,7 +77,7 @@ def main(bus, process, name_for_stdin, results_filter, files):
         process(bus, name_for_stdin if fileinput.isstdin()
                 else os.path.basename(fileinput.filename()), parsed_line[0],
                 parsed_line[1], parsed_line[2], [parsed_line[i:i+2]
-                    for i in range(1, len(parsed_line)-1,2)])
+                    for i in range(3, len(parsed_line)-1,2)])
     return True
 
 if __name__ == '__main__':

--- a/scripts/reprogen.py
+++ b/scripts/reprogen.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
 import argparse
+import fileinput
 import sys
 
-def main(bus, target, name_for_stdin, files):
+def main(bus, target, name_for_stdin, results_filter, files):
     if name_for_stdin is None and '-' in files:
         return False
+    for line in fileinput.input(files):
+        print(line)
     return True
 
 if __name__ == '__main__':
@@ -18,11 +21,14 @@ if __name__ == '__main__':
             default='dbus-send', help='Target language/library')
     p.add_argument('-n', '--name', type=str, default=None,
             help='Name of the bus to use when taking input from stdin')
+    p.add_argument('-f', '--filter', type=str, choices=['Crash','Success',
+        'Command execution error'], default='[Crash]', nargs='+',help=
+        'List of result types for which reproduction code will be generated')
     p.add_argument('files', type=str, nargs='+',
             help='Paths to log files ("-" for stdin)')
     args = p.parse_args()
     if not main('system' if args.system else 'session', args.target, args.name,
-            args.files):
+            args.filter, args.files):
         p.print_usage(file=sys.stderr)
         print('{}: When taking input from stdin, you must specify bus name'
                 .format(sys.argv[0]))

--- a/scripts/reprogen.py
+++ b/scripts/reprogen.py
@@ -1,3 +1,29 @@
 #!/usr/bin/env python3
 
 import argparse
+import sys
+
+def main(bus, target, name_for_stdin, files):
+    if name_for_stdin is None and '-' in files:
+        return False
+    return True
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser(
+            description='Generate reproduction code from dfuzzer logs')
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument('--system',  action='store_true', help='Use system bus')
+    g.add_argument('--session', action='store_true', help='Use session bus')
+    p.add_argument('-t', '--target', choices=['dbus-send'],
+            default='dbus-send', help='Target language/library')
+    p.add_argument('-n', '--name', type=str, default=None,
+            help='Name of the bus to use when taking input from stdin')
+    p.add_argument('files', type=str, nargs='+',
+            help='Paths to log files ("-" for stdin)')
+    args = p.parse_args()
+    if not main('system' if args.system else 'session', args.target, args.name,
+            args.files):
+        p.print_usage(file=sys.stderr)
+        print('{}: When taking input from stdin, you must specify bus name'
+                .format(sys.argv[0]))
+        exit(2)

--- a/scripts/reprogen.py
+++ b/scripts/reprogen.py
@@ -26,7 +26,7 @@ def dbus_send_format(args):
         if arg[0] in DBUS_SEND_DICT:
             ret += "{}:{} ".format(DBUS_SEND_DICT[arg[0]], arg[1])
         elif arg[0] in DBUS_SEND_STRINGS_DICT:
-            ret += "{}:`echo {} | xxd -r -p` ".format(
+            ret += '{}:"`echo {} | xxd -r -p`" '.format(
                     DBUS_SEND_STRINGS_DICT[arg[0]], arg[1])
         else:
             print("Argument type {} unsupported for dbus_send".format(arg[0]),

--- a/scripts/reprogen.py
+++ b/scripts/reprogen.py
@@ -17,7 +17,7 @@ def main(bus, process, name_for_stdin, results_filter, files):
             continue
         process(bus, name_for_stdin if fileinput.isstdin()
                 else os.path.basename(fileinput.filename()), parsed_line[0],
-                [parsed_line[i:i+1] for i in range(1, len(parsed_line),2)])
+                [parsed_line[i:i+2] for i in range(1, len(parsed_line)-1,2)])
     return True
 
 if __name__ == '__main__':

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -710,6 +710,7 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
 		// else continue, we managed to get process memory size
 		prev_memory = used_memory;
 
+		FULL_LOG("%s;%s;", intf, obj);
 
 		if(logfile) df_fuzz_write_log();
 		FULL_LOG("Success\n");
@@ -735,6 +736,7 @@ fail_label:
 	df_mem_limit = -1;		// set to -1 to reload memory limit
 	if (ret != 1) {
 		df_fail("   on input:\n");
+		FULL_LOG("%s;%s;", intf, obj);
 		df_fuzz_write_log();
 	}
 	if (value != NULL)


### PR DESCRIPTION
This is a simple Python 3 script which generates either dbus-send or gdbus commands (depending on command-line switches) to reproduce crashes. It can take input from files or stdin, is quite configurable and generally seems to work well.

Issues and possible improvements:
+ sometimes the logs get malformed and we get too many interface names and object paths; the generator can deal with that, but this is somewhat of a hack. I'm not sure why it happens but I assume that it's because a function that ```df_fuzz_write_log()``` is skipped or exits early for some reason
+ the output assumes that we will be calling dbus-send/gdbus with a shell and decodes hex strings by ```echo```ing them, piping that to ```xxd``` and inserting the output into the call. I'm not sure if xxd is an acceptable dependency for those reproduction scripts,  but obviously we can't put random raw bytes in there; an alternative could be decoding from Python and writing those bytes to a file and putting its contents in our command with cat, but I'm not sure about spamming temporary files for each string.
+ we might want to add more templates - e.g. pydbus