### PR TITLE
dfuzzer.c：modify df_open_proc_status_file

### DIFF
--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -852,7 +852,7 @@ int df_is_valid_dbus(const char *name, const char *obj, const char *intf)
  */
 int df_open_proc_status_file(const int pid)
 {
-	char file_path[20];		// "/proc/(max5chars)/status"
+	char file_path[25];		// "/proc/(max10chars)/status"
 	sprintf(file_path, "/proc/%d/status", pid);
 
 	int statfd = open(file_path, O_RDONLY);


### PR DESCRIPTION
Extend file_path[20] to file_path[25]. Because
max5chars is too short for pid sometimes.

Signed-off-by: Zhu Huankai <283014003@qq.com>