### PR TITLE
Don't crash when $HOME is unset

### DIFF
--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -1240,20 +1240,22 @@ int df_load_suppressions(void)
 		goto file_open;
 	// home dir
 	env = getenv("HOME");
-	sup_file = malloc(sizeof(char) * (strlen(env) + strlen(SF2) + 2));
-	if (sup_file == NULL) {
-		df_fail("Error: Could not allocate memory for suppression file name\n");
-		return -1;
+	if (env) {
+		sup_file = malloc(sizeof(char) * (strlen(env) + strlen(SF2) + 2));
+		if (sup_file == NULL) {
+			df_fail("Error: Could not allocate memory for suppression file name\n");
+			return -1;
+		}
+		sprintf(sup_file, "%s/%s", env, SF2);
+		f = fopen(sup_file, "r");
+		if (f == NULL) {
+			df_verbose("'%s' file not found.\n", sup_file);
+			free(sup_file);
+			env = NULL;
+		}
+		else
+			goto file_open;
 	}
-	sprintf(sup_file, "%s/%s", env, SF2);
-	f = fopen(sup_file, "r");
-	if (f == NULL) {
-		df_verbose("'%s' file not found.\n", sup_file);
-		free(sup_file);
-		env = NULL;
-	}
-	else
-		goto file_open;
 	// dir /etc
 	sup_file = SF3;		// mandatory (must exist)
 	f = fopen(sup_file, "r");


### PR DESCRIPTION
When running from a systemd service (or any other environment where
$HOME is not set) dfuzzer crashes when it attempts to load the
suppression file. Let's skip the $HOME-bound suppression file checks in
such cases to avoid that.

Reproducer:
```
 # systemd-run --pipe --wait -- dfuzzer -n org.freedesktop.resolve1
 Running as unit: run-u51.service
 Finished with result: core-dump
 Main processes terminated with: code=dumped/status=SEGV
 Service runtime: 104ms
 CPU time consumed: 3ms

 # echo -e 'bt\nquit\n' | coredumpctl gdb dfuzzer
 Program terminated with signal SIGSEGV, Segmentation fault.
 #0  0x00007f51857434bd in __strlen_avx2 () from /usr/lib/libc.so.6
 #1  0x000055b3a1d55375 in df_load_suppressions () at dfuzzer.c:1243
 #2  0x000055b3a1d5352f in main (argc=<optimized out>, argv=<optimized out>) at dfuzzer.c:116
```