### PR TITLE
Properly terminate the suppression strings

### DIFF
--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -1327,6 +1327,8 @@ file_open:
 			df_suppression[i][j++] = *ptr;
 			ptr++;
 		}
+		df_suppression[i][j] = '\0';
+
 		j = 0;
 		if (*ptr != '\n') {
 			ptr++;	// skips the space
@@ -1335,6 +1337,7 @@ file_open:
 				ptr++;
 			}
 		}
+		df_supp_description[i][j] = '\0';
 	}
 	df_suppression[i] = NULL;
 	if (ferror(f)) {


### PR DESCRIPTION
I stumbled across a head scratcher, where dfuzzer kept ignoring my
suppression rule for the 'Halt' method of the org.freedesktop.login1
interface. Turns out there's a heap-buffer-overflow present in the
suppression-parsing code, causing the issue, since the suppression
method name would have trailing (and usually unprintable) characters.

Example (with some supporting code changes):
```
cat >dfuzzer.conf <<EOF
[org.freedesktop.login1]
Halt destructive
Hibernate destructive
HaltWithFlags destructive
Hibernate destructive
HibernateWithFlags destructive
HybridSleep destructive
HybridSleepWithFlags destructive
KillSession destructive
KillUser destructive
LockSession destructive
LockSessions destructive
PowerOff destructive
PowerOffWithFlags destructive
Reboot destructive
RebootWithFlags destructive
ReleaseSession destructive
ScheduleShutdown destructive
Suspend destructive
SuspendThenHibernate destructive
SuspendThenHibernateWithFlags destructive
SuspendWithFlags destructive
TerminateSeat destructive
TerminateSession destructive
TerminateUser destructive
EOF

dfuzzer -d -v -n org.freedesktop.login1
...
SKIP RebootWithFlags - destructive
CURRENT METHOD: Halt
CHECKING Halt�U ( 'H' 'a' 'l' 't' '�' 'U')
CHECKING Hibernate ( 'H' 'i' 'b' 'e' 'r' 'n' 'a' 't' 'e')
...
Refusing to halt the machine
Exit status: 1
```

Also, when compiled with `-fsanitize=address,undefined`:
```
==41164==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x611000000b40 at pc 0x7f49b374662b bp 0x7fff5d894d70 sp 0x7fff5d894518
READ of size 267 at 0x611000000b40 thread T0
    #0 0x7f49b374662a in __interceptor_strlen /usr/src/debug/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:389
    #1 0x5643d608fddf in df_fuzz /root/dfuzzer/src/dfuzzer.c:675
    #2 0x5643d609120c in df_traverse_node /root/dfuzzer/src/dfuzzer.c:531
    #3 0x5643d608aee8 in main /root/dfuzzer/src/dfuzzer.c:231
    #4 0x7f49b284630f in __libc_start_call_main (/usr/lib/libc.so.6+0x2d30f)
    #5 0x7f49b28463c0 in __libc_start_main@GLIBC_2.2.5 (/usr/lib/libc.so.6+0x2d3c0)
    #6 0x5643d608b544 in _start (/root/dfuzzer/src/dfuzzer+0x1a544)

0x611000000b40 is located 0 bytes to the right of 256-byte region [0x611000000a40,0x611000000b40)
allocated by thread T0 here:
    #0 0x7f49b37bfdd9 in __interceptor_malloc /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x5643d608e81f in df_load_suppressions /root/dfuzzer/src/dfuzzer.c:1322
    #2 0x6576697463757273  (<unknown module>)

SUMMARY: AddressSanitizer: heap-buffer-overflow /usr/src/debug/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:389 in __interceptor_strlen
Shadow bytes around the buggy address:
  0x0c227fff8110: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x0c227fff8120: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c227fff8130: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c227fff8140: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c227fff8150: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c227fff8160: 00 00 00 00 00 00 00 00[fa]fa fa fa fa fa fa fa
  0x0c227fff8170: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c227fff8180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c227fff8190: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c227fff81a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c227fff81b0: 00 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
```