### PR TITLE
Account for kernel.pid_max > 65535

### DIFF
--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -928,7 +928,7 @@ int df_get_pid(const GDBusConnection *dcon)
  */
 void df_print_process_info(int pid)
 {
-	char proc_path[20];            // "/proc/(max5chars)/[exe|cmdline]"
+	char proc_path[15+DECIMAL_STR_MAX(int)]; // "/proc/(int)/[exe|cmdline]"
 	char name[PATH_MAX];           // for storing process and package name
 	char buf[PATH_MAX + MAXLEN];   // buffer for rpm/dpkg request
 	FILE *fp;

--- a/src/dfuzzer.h
+++ b/src/dfuzzer.h
@@ -37,6 +37,16 @@
 /** Maximum length of strings containing D-Bus name, interface and object path */
 #define MAXLEN 256
 
+/* Returns the number of chars needed to format variables of the
+ * specified type as a decimal string. Adds in extra space for a
+ * negative '-' prefix (hence works correctly on signed
+ * types). Includes space for the trailing NUL. */
+#define DECIMAL_STR_MAX(type)                                           \
+        (2U+(sizeof(type) <= 1 ? 3U :                                   \
+             sizeof(type) <= 2 ? 5U :                                   \
+             sizeof(type) <= 4 ? 10U :                                  \
+             sizeof(type) <= 8 ? 20U : sizeof(int[-2*(sizeof(type) > 8)])))
+
 /** Structure containing D-Bus name, object path and interface of process. */
 struct fuzzing_target {
 	/* names on D-Bus have the most MAXLEN characters */


### PR DESCRIPTION
Today's `kernel.pid_max=` is usually set to 2^22 (4194304) instead of
the original 2^16 (65535), causing buffer overflow when trying to write
`/proc/<PID>/cmdline` into the stack-allocated buffer. Let's fix this by
using the maximum "string length" of int (calculated using a macro
borrowed from systemd, which might be useful in the future).

Fixes: #11