### PR TITLE
dfuzzer.conf: add more destructive systemd methods

### DIFF
--- a/src/dfuzzer.conf
+++ b/src/dfuzzer.conf
@@ -91,3 +91,10 @@ AddInhibition expected high memory consumption (BZ#1017220)
 
 [org.gnome.evolution.dataserver.Sources1]
 Authenticate expected high memory consumption (BZ#1022530)
+
+[org.freedesktop.systemd1]
+Exit destructive
+Halt destructive
+KExec destructive
+PowerOff destructive
+Reboot destructive


### PR DESCRIPTION
dfuzzer doesn't poke void methods yet but once https://github.com/matusmarhefka/dfuzzer/issues/18
is implemented all those methods should be blocked.

It should help to somewhat cover the code parsing dfuzzer.conf on GHActions
with sanitizers though.