### PR TITLE
A couple more Coverity-related tweaks

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,9 +12,6 @@ libffi = dependency('libffi', required : true)
 
 subdir('src')
 
-# https://github.com/matusmarhefka/dfuzzer/issues/30
-add_project_arguments('-Wno-unused-parameter', language : 'c')
-
 executable(
         'dfuzzer',
         dfuzzer_sources,

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@
 
 CC ?= gcc
 # See: https://www.gnu.org/software/make/manual/make.html#Override-Directive
-override CFLAGS += -Wall -Wno-unused-parameter -O2 -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 `pkg-config --cflags --libs gio-2.0 libffi` -g
+override CFLAGS += -Wall -O2 -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 `pkg-config --cflags --libs gio-2.0 libffi` -g
 OBJ = dfuzzer.o introspection.o fuzz.o rand.o util.o
 TARGET = dfuzzer
 all: dfuzzer

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -539,7 +539,7 @@ int df_fuzz(GDBusConnection *dcon, const char *name, const char *obj, const char
         }
 
         // Introspection of object through proxy.
-        if (df_init_introspection(dproxy, name, intf) == -1) {
+        if (df_init_introspection(dproxy, intf) == -1) {
                 df_debug("Error in df_init_introspection() on introspecting object\n");
                 return DF_BUS_ERROR;
         }

--- a/src/introspection.c
+++ b/src/introspection.c
@@ -43,11 +43,10 @@ static GDBusArgInfo **df_out_args;
  * At the end looks up information about an interface and initializes module
  * global pointers on first method and its first argument.
  * @param dproxy Pointer on D-Bus interface proxy
- * @param name D-Bus name
  * @param interface D-Bus interface
  * @return 0 on success, -1 on error
  */
-int df_init_introspection(GDBusProxy *dproxy, const char *name, const char *interface)
+int df_init_introspection(GDBusProxy *dproxy, const char *interface)
 {
         if (!dproxy || !interface) {
                 df_debug("Passing NULL argument to function.\n");

--- a/src/introspection.h
+++ b/src/introspection.h
@@ -26,11 +26,10 @@
  * At the end looks up information about an interface and initializes module
  * global pointers on first method and its first argument.
  * @param dproxy Pointer on D-Bus interface proxy
- * @param name D-Bus name
  * @param interface D-Bus interface
  * @return 0 on success, -1 on error
  */
-int df_init_introspection(GDBusProxy *dproxy, const char *name, const char *interface);
+int df_init_introspection(GDBusProxy *dproxy, const char *interface);
 
 /**
  * @return Pointer on GDBusMethodInfo which contains information about method

--- a/src/rand.c
+++ b/src/rand.c
@@ -57,8 +57,8 @@ static long df_str_len;
 static const char *df_str_def[] = {
         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         "%s%s%s%s%s%s%s%s%s%n%s%n%n%n%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
-        "%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n"
-        "%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n",
+        ("%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n"
+        "%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n"),
         "bomb(){ bomb|bomb & }; bomb",
         ":1.285",
         "org.freedesktop.foo",


### PR DESCRIPTION
The code annotations for `rand()` and `random()` feel a bit icky (I wish there was an option to disable the warning for the whole file), but it is what it is. I guess the other option would be to suppress them manually in the UI.

The remaining Coverity warnings will require a bit more work.

Also, this fixes #30 - the `name` parameter was originally used just in the error paths, but the `name` argument was dropped in 15a6d7b9f60269fdf5e3febb61eb45e481873a8c, so was completely unused since then.