### PR TITLE
ci: switch to meson on LGTM as well

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -6,7 +6,3 @@ extraction:
         - gcc
         - libglib2.0-dev
         - libffi-dev
-        - make
-    index:
-      build_command:
-        - make -C src


### PR DESCRIPTION
LGTM can detect meson projects automatically