### PR TITLE
ci: run dfuzzer under Valgrind as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,9 @@ jobs:
               ASAN_OPTIONS: "strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:abort_on_error=1",
               UBSAN_OPTIONS: "print_stacktrace=1:print_summary=1:halt_on_error=1"
             }
+          - {
+              TYPE: "valgrind",
+            }
     env: ${{ matrix.env }}
     name: ${{ matrix.env.TYPE }}
     steps:
@@ -54,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt -y update
-          sudo apt -y install gcc libglib2.0-dev libffi-dev meson clang
+          sudo apt -y install gcc libglib2.0-dev libffi-dev meson clang valgrind
 
       - name: Build
         run: |

--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -2,25 +2,30 @@
 
 set -ex
 
-dfuzzer -V
-dfuzzer --version
-dfuzzer -s -l
-dfuzzer --no-suppressions --list
+dfuzzer=dfuzzer
+if [[ "$TYPE" == valgrind ]]; then
+    dfuzzer='valgrind --leak-check=full --show-leak-kinds=definite --errors-for-leak-kinds=definite --error-exitcode=1 dfuzzer'
+fi
+
+$dfuzzer -V
+$dfuzzer --version
+$dfuzzer -s -l
+$dfuzzer --no-suppressions --list
 # Test as an unprivileged user (short options)
-dfuzzer -v -n org.freedesktop.systemd1
+$dfuzzer -v -n org.freedesktop.systemd1
 # Test as root (long options + duplicate options)
-sudo dfuzzer --verbose --bus this.should.be.ignored --bus org.freedesktop.systemd1
+sudo $dfuzzer --verbose --bus this.should.be.ignored --bus org.freedesktop.systemd1
 # Test logdir
 mkdir dfuzzer-logs
-dfuzzer --log-dir dfuzzer-logs -v -n org.freedesktop.systemd1
+$dfuzzer --log-dir dfuzzer-logs -v -n org.freedesktop.systemd1
 # Test a non-existent bus
-if sudo dfuzzer --log-dir "" --bus this.should.not.exist; then false; fi
+if sudo $dfuzzer --log-dir "" --bus this.should.not.exist; then false; fi
 # Test object & interface options
-dfuzzer -v --bus org.freedesktop.systemd1 --object / --interface org.freedesktop.DBus.Peer
-sudo dfuzzer -v --bus org.freedesktop.systemd1 --object / --interface org.freedesktop.DBus.Peer
+$dfuzzer -v --bus org.freedesktop.systemd1 --object / --interface org.freedesktop.DBus.Peer
+sudo $dfuzzer -v --bus org.freedesktop.systemd1 --object / --interface org.freedesktop.DBus.Peer
 # - duplicate object/interface paths
-dfuzzer -v --bus org.freedesktop.systemd1 --object xxx --object yyy --object / --interface org.freedesktop.DBus.Peer
-dfuzzer -v --bus org.freedesktop.systemd1 --object xxx --object yyy --object / --interface zzz --interface org.freedesktop.DBus.Peer
+$dfuzzer -v --bus org.freedesktop.systemd1 --object xxx --object yyy --object / --interface org.freedesktop.DBus.Peer
+$dfuzzer -v --bus org.freedesktop.systemd1 --object xxx --object yyy --object / --interface zzz --interface org.freedesktop.DBus.Peer
 # - test error paths
-if dfuzzer -v --bus org.freedesktop.systemd1 --object aaa; then false; fi
-if dfuzzer -v --bus org.freedesktop.systemd1 --interface aaa; then false; fi
+if $dfuzzer -v --bus org.freedesktop.systemd1 --object aaa; then false; fi
+if $dfuzzer -v --bus org.freedesktop.systemd1 --interface aaa; then false; fi

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -913,6 +913,10 @@ static int df_fuzz_create_list_variants(void)
                 } else {    // advanced argument (array of something, dictionary, ...)
                         // fprintf(stderr, "Advanced signatures not yet implemented\n");
                         df_unsupported_sig_str = s->sig;
+                        for (s = df_list.list; s && s->var; s = s->next) {
+                                g_variant_unref(s->var);
+                                s->var = NULL;
+                        }
                         return 1;   // unsupported method signature
                 }
 

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -533,7 +533,6 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
                 return 0;
 
         struct df_signature *s = df_list.list;  // pointer on the first signature
-        _cleanup_(g_variant_unrefp) GVariant *value = NULL;
         int ret = 0;            // return value from df_fuzz_call_method()
         int execr = 0;          // return value from execution of execute_cmd
         int leaking_mem_flg = 0;            // if set to 1, leaks were detected
@@ -562,6 +561,8 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
         df_verbose("  %s...", df_list.df_method_name);
 
         while (df_rand_continue(df_list.fuzz_on_str_len)) {
+                _cleanup_(g_variant_unrefp) GVariant *value = NULL;
+
                 // parsing proces memory size from its status file described by statfd
                 used_memory = df_fuzz_get_proc_mem_size(statfd);
                 if (used_memory == -1) {


### PR DESCRIPTION
and two memory leaks were fixed along the way
```sh
22,255 (3,456 direct, 18,799 indirect) bytes in 72 blocks are definitely lost in loss record 1,096 of 1,096
    at 0x484486F: malloc (vg_replace_malloc.c:381)
    by 0x4AF7428: g_malloc (gmem.c:106)
    by 0x4B10074: g_slice_alloc (gslice.c:1072)
    by 0x4B2F772: UnknownInlinedFun (gvariant-core.c:486)
    by 0x4B2F772: UnknownInlinedFun (gvariant-core.c:624)
    by 0x4B2F772: g_variant_builder_end (gvariant.c:3725)
    by 0x4B32FA3: g_variant_valist_new (gvariant.c:5236)
    by 0x4B33571: g_variant_new_va (gvariant.c:5409)
    by 0x4B336C3: g_variant_new (gvariant.c:5344)
    by 0x4BDEC03: ffi_call_unix64 (unix64.S:76)
    by 0x4BDE107: ffi_call (ffi64.c:525)
    by 0x4056D6: df_fuzz_create_variant (fuzz.c:798)
    by 0x40643C: df_fuzz_test_method (fuzz.c:576)
    by 0x403FDD: df_fuzz (dfuzzer.c:624)

...
LEAK SUMMARY:
    definitely lost: 1,791,744 bytes in 37,328 blocks
    indirectly lost: 8,317,032 bytes in 170,449 blocks
```
```sh
 552 (288 direct, 264 indirect) bytes in 6 blocks are definitely lost in loss record 1,063 of 1,080
    at 0x484486F: malloc (vg_replace_malloc.c:381)
    by 0x4AF7428: g_malloc (gmem.c:106)
    by 0x4B10074: g_slice_alloc (gslice.c:1072)
    by 0x4B311E1: UnknownInlinedFun (gvariant-core.c:486)
    by 0x4B311E1: g_variant_new_from_bytes (gvariant-core.c:529)
    by 0x4B31614: UnknownInlinedFun (gvariant.c:326)
    by 0x4B31614: g_variant_new_int32 (gvariant.c:490)
    by 0x4B33571: g_variant_new_va (gvariant.c:5409)
    by 0x4B336C3: g_variant_new (gvariant.c:5344)
   by 0x4071A8: df_fuzz_create_list_variants (fuzz.c:855)
    by 0x406E82: df_fuzz_create_variant (fuzz.c:766)
    by 0x406596: df_fuzz_test_method (fuzz.c:577)
    by 0x403DB0: df_fuzz (dfuzzer.c:624)
   by 0x403763: df_traverse_node (dfuzzer.c:450)
...
 LEAK SUMMARY:
    definitely lost: 576 bytes in 12 blocks
    indirectly lost: 755 bytes in 24 blocks
```
