### PR TITLE
dfuzzer: skip loading suppressions when no proc name is specified

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -9,6 +9,7 @@ fi
 
 $dfuzzer -V
 $dfuzzer --version
+$dfuzzer -l
 $dfuzzer -s -l
 $dfuzzer --no-suppressions --list
 # Test a long suppression file

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -1034,6 +1034,9 @@ int df_load_suppressions(void)
         int name_found = 0, i = 0;
         size_t len = 0;
 
+        if (isempty(target_proc.name))
+                return 0;
+
         env = getenv("HOME");
         if (env) {
                 home_supp = strjoin(env, "/", SF2);

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -1032,7 +1032,7 @@ int df_load_suppressions(void)
         _cleanup_free_ char *line = NULL, *home_supp = NULL;
         char *env = NULL;
         int name_found = 0, i = 0;
-        size_t len = 0;
+        size_t len = 0, n;
 
         if (isempty(target_proc.name))
                 return 0;
@@ -1084,10 +1084,14 @@ int df_load_suppressions(void)
         df_verbose("Found suppressions for bus: '%s'\n", target_proc.name);
 
         i = 0;
-        while (i < (MAXLEN - 1) && getline(&line, &len, f) > 0) {
+        while (i < (MAXLEN - 1) && (n = getline(&line, &len, f)) > 0) {
                 _cleanup_free_ char *suppression = NULL, *description = NULL;
                 if (line[0] == '[')
                         break;
+
+                /* The line contains only whitespace, skip it */
+                if (strspn(line, " \t\r\n") == n)
+                        continue;
 
                 /* The suppression description is optional, so let's accept such
                  * lines as well */

--- a/src/dfuzzer.conf
+++ b/src/dfuzzer.conf
@@ -23,6 +23,13 @@ TerminateSeat destructive
 TerminateSession destructive
 TerminateUser destructive
 
+[org.freedesktop.systemd1]
+Exit destructive
+Halt destructive
+KExec destructive
+PowerOff destructive
+Reboot destructive
+
 [org.freedesktop.timedate1]
 SetLocalRTC destructive method breaking the RTC and system time
 SetNTP destructive method turning off systemd-timesyncd
@@ -91,10 +98,3 @@ AddInhibition expected high memory consumption (BZ#1017220)
 
 [org.gnome.evolution.dataserver.Sources1]
 Authenticate expected high memory consumption (BZ#1022530)
-
-[org.freedesktop.systemd1]
-Exit destructive
-Halt destructive
-KExec destructive
-PowerOff destructive
-Reboot destructive


### PR DESCRIPTION
Resolves: #43

---

CI didn't catch this, since we only tested `dfuzzer -s -l`, i.e. skipping the suppression part.