### PR TITLE
Revert "fix a huge memory leak"

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -4,7 +4,10 @@ set -ex
 
 dfuzzer=dfuzzer
 if [[ "$TYPE" == valgrind ]]; then
-    dfuzzer='valgrind --leak-check=full --show-leak-kinds=definite --errors-for-leak-kinds=definite --error-exitcode=1 dfuzzer'
+    # leak-check=full should be brought back once https://github.com/matusmarhefka/dfuzzer/issues/45
+    # is addressed properly. Until then let's use valgrind to make sure uninitizlized memory isn't
+    # used anywhere.
+    dfuzzer='valgrind --leak-check=no --show-leak-kinds=definite --errors-for-leak-kinds=definite --error-exitcode=1 dfuzzer'
 fi
 
 $dfuzzer -V

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -533,6 +533,7 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
                 return 0;
 
         struct df_signature *s = df_list.list;  // pointer on the first signature
+        _cleanup_(g_variant_unrefp) GVariant *value = NULL;
         int ret = 0;            // return value from df_fuzz_call_method()
         int execr = 0;          // return value from execution of execute_cmd
         int leaking_mem_flg = 0;            // if set to 1, leaks were detected
@@ -561,8 +562,6 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
         df_verbose("  %s...", df_list.df_method_name);
 
         while (df_rand_continue(df_list.fuzz_on_str_len)) {
-                _cleanup_(g_variant_unrefp) GVariant *value = NULL;
-
                 // parsing proces memory size from its status file described by statfd
                 used_memory = df_fuzz_get_proc_mem_size(statfd);
                 if (used_memory == -1) {


### PR DESCRIPTION
It should temporarily address https://github.com/matusmarhefka/dfuzzer/issues/45

This reverts commit 1c7753a9730d6d0add98b169f8ec32061e90d2ce.