### PR TITLE
fuzz: avoid leaking memory

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -4,10 +4,7 @@ set -ex
 
 dfuzzer=dfuzzer
 if [[ "$TYPE" == valgrind ]]; then
-    # leak-check=full should be brought back once https://github.com/matusmarhefka/dfuzzer/issues/45
-    # is addressed properly. Until then let's use valgrind to make sure uninitizlized memory isn't
-    # used anywhere.
-    dfuzzer='valgrind --leak-check=no --show-leak-kinds=definite --errors-for-leak-kinds=definite --error-exitcode=1 dfuzzer'
+    dfuzzer='valgrind --leak-check=full --show-leak-kinds=definite --errors-for-leak-kinds=definite --error-exitcode=1 dfuzzer'
 fi
 
 $dfuzzer -V

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -676,16 +676,10 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
                                 "   [PID: %d], [MEM: %ld kB]\n",
                                 ansi_cr(), ansi_red(), ansi_normal(),
                                 df_list.df_method_name, pid, prev_memory);
-                        if (execr > 0)
-                                df_fail("%s   '%s' returned %s%d%s\n",
-                                        ansi_cr(), execute_cmd, ansi_red(), execr, ansi_normal());
                         goto fail_label;
                 } else if (used_memory == -1) { // error on reading process status
                         df_fail("Error: Unable to get memory size of [PID:%d].\n", pid);
                         df_debug("Error in df_fuzz_get_proc_mem_size()\n");
-                        if (execr > 0)
-                                df_fail("%s   '%s' returned %s%d%s\n",
-                                        ansi_cr(), execute_cmd, ansi_red(), execr, ansi_normal());
                         return -1;
                 }
                 // else continue, we managed to get process memory size


### PR DESCRIPTION
Temporary kludge to stop leaking memory while simultaneously not crashing
when the fuzzed app crashes.

This also reverts commit 5e0028f2dde2742cd8b90d94ac1a6569c6718aa0.

Resolves: #45

---

The offending code is in a serious need of refactoring, but until then let's avoid both the memory leak and the crash using a relatively... simple-ish kludge.