### PR TITLE
test-server: make the test-server compatible with -Werror

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build
         run: |
-          meson build
+          meson -Ddfuzzer-test-server=true build
           ninja -C ./build -v
           sudo ninja -C ./build install
 

--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,8 @@ if get_option('dfuzzer-test-server')
                 'dfuzzer-test-server',
                 dfuzzer_test_server_sources,
                 dependencies : [libgio],
-                install : true
+                c_args : '-Wno-unused-parameter',
+                install : true,
         )
 endif
 

--- a/src/dfuzzer-test-server.c
+++ b/src/dfuzzer-test-server.c
@@ -30,7 +30,7 @@
  * --method org.freedesktop.DBus.ListNames | grep org.freedesktop.dfuzzerServer
  */
 #include <gio/gio.h>
-#include <glib/gstdio.h>	// g_printf() function
+#include <glib/gstdio.h>        // g_printf() function
 #include <stdlib.h>
 #include <string.h>
 
@@ -41,121 +41,121 @@ static GDBusNodeInfo *introspection_data = NULL;
 // Introspection data for the service we are exporting.
 static const gchar introspection_xml[] =
 "<node>"
-"	<interface name=\"org.freedesktop.dfuzzerInterface\">"
-"		<method name=\"df_hello\">"
-"			<arg type=\"s\" name=\"msg\" direction=\"in\"/>"
-"			<arg type=\"i\" name=\"lol\" direction=\"in\"/>"
-"			<arg type=\"s\" name=\"response\" direction=\"out\"/>"
-"		</method>"
-"	</interface>"
+"       <interface name=\"org.freedesktop.dfuzzerInterface\">"
+"               <method name=\"df_hello\">"
+"                       <arg type=\"s\" name=\"msg\" direction=\"in\"/>"
+"                       <arg type=\"i\" name=\"lol\" direction=\"in\"/>"
+"                       <arg type=\"s\" name=\"response\" direction=\"out\"/>"
+"               </method>"
+"       </interface>"
 "</node>";
 
 
 static void handle_method_call(GDBusConnection *connection, const gchar *sender,
-	const gchar *object_path, const gchar *interface_name,
-	const gchar *method_name, GVariant *parameters,
-	GDBusMethodInvocation *invocation, gpointer user_data)
+        const gchar *object_path, const gchar *interface_name,
+        const gchar *method_name, GVariant *parameters,
+        GDBusMethodInvocation *invocation, gpointer user_data)
 {
-	g_printf("->[handle_method_call]\n");
+        g_printf("->[handle_method_call]\n");
 
-	if (g_strcmp0(method_name, "df_hello") == 0) {
-		gchar *msg;
-		gchar buf[5000];
-		int n;
-		gchar *response;
+        if (g_strcmp0(method_name, "df_hello") == 0) {
+                gchar *msg;
+                gchar buf[5000];
+                int n;
+                gchar *response;
 
-		// Deconstructs a GVariant instance parameters into gchar * msg.
-		// "(&s)" means msg will point inside parameters structure, so do not
-		// free it. If we would use "(s)", it is safe to free msg as data would
-		// be only copied.
-		g_variant_get(parameters, "(&si)", &msg, &n);
+                // Deconstructs a GVariant instance parameters into gchar * msg.
+                // "(&s)" means msg will point inside parameters structure, so do not
+                // free it. If we would use "(s)", it is safe to free msg as data would
+                // be only copied.
+                g_variant_get(parameters, "(&si)", &msg, &n);
 
-		g_printf("\n@@@\nMsg from Client: [--s-- \'%s\'\n--i-- \'%d\']\n", msg, n);
-		response = g_strdup_printf("%s", msg);
+                g_printf("\n@@@\nMsg from Client: [--s-- \'%s\'\n--i-- \'%d\']\n", msg, n);
+                response = g_strdup_printf("%s", msg);
 
-		//strcpy(buf, msg);		// XXX: segfault if uncommented
-		// Finishes handling a D-Bus method call by returning response
-		// converted to GVariant. This method will free invocation,
-		// you cannot use it afterwards.
-		g_dbus_method_invocation_return_value(invocation,
-			g_variant_new("(s)", response));
-		g_printf("Sending response to Client: [%s]\n", response);
-		g_free(response);		// XXX: memory leaks if commented
-	}
+                //strcpy(buf, msg);             // XXX: segfault if uncommented
+                // Finishes handling a D-Bus method call by returning response
+                // converted to GVariant. This method will free invocation,
+                // you cannot use it afterwards.
+                g_dbus_method_invocation_return_value(invocation,
+                        g_variant_new("(s)", response));
+                g_printf("Sending response to Client: [%s]\n", response);
+                g_free(response);               // XXX: memory leaks if commented
+        }
 }
 
 // Virtual table for handling properties and method calls for a D-Bus interface.
 static const GDBusInterfaceVTable interface_vtable =
 {
-	handle_method_call,
-	NULL,
-	NULL
+        handle_method_call,
+        NULL,
+        NULL
 };
 
 
 static void bus_acquired(GDBusConnection *connection, const gchar *name,
-	gpointer user_data)
+        gpointer user_data)
 {
-	g_printf("->[bus_acquired]\n");
+        g_printf("->[bus_acquired]\n");
 
-	guint reg_id;
+        guint reg_id;
 
-	// Registers callbacks for exported objects at
-	// /org/freedesktop/dfuzzerObject with the D-Bus interface that is
-	// described in introspection_data->interfaces[0].
-	reg_id = g_dbus_connection_register_object(connection,
-				"/org/freedesktop/dfuzzerObject",
-				introspection_data->interfaces[0],
-				&interface_vtable,
-				NULL,	// user_data
-				NULL,	// user_data_free_func
-				NULL);	// GError**
-	g_assert(reg_id > 0);
+        // Registers callbacks for exported objects at
+        // /org/freedesktop/dfuzzerObject with the D-Bus interface that is
+        // described in introspection_data->interfaces[0].
+        reg_id = g_dbus_connection_register_object(connection,
+                                "/org/freedesktop/dfuzzerObject",
+                                introspection_data->interfaces[0],
+                                &interface_vtable,
+                                NULL,   // user_data
+                                NULL,   // user_data_free_func
+                                NULL);  // GError**
+        g_assert(reg_id > 0);
 }
 
 static void name_acquired(GDBusConnection *connection, const gchar *name,
-	gpointer user_data)
+        gpointer user_data)
 {
-	g_printf("->[name_acquired]\n");
+        g_printf("->[name_acquired]\n");
 }
 
 static void name_lost(GDBusConnection *connection, const gchar *name,
-	gpointer user_data)
+        gpointer user_data)
 {
-	g_printerr("Unable to connect to the bus daemon!\n");
-	exit(1);
+        g_printerr("Unable to connect to the bus daemon!\n");
+        exit(1);
 }
 
 int main(int argc, char **argv)
 {
-	guint name_id;
-	GMainLoop *loop;
+        guint name_id;
+        GMainLoop *loop;
 
-	// Initializes the type system.
-	g_type_init();
+        // Initializes the type system.
+        g_type_init();
 
-	// Parses introspection_xml and returns a GDBusNodeInfo representing the data.
-	// The introspection XML must contain exactly one top-level <node> element.
-	introspection_data = g_dbus_node_info_new_for_xml(introspection_xml, NULL);
-	g_assert(introspection_data != NULL);
+        // Parses introspection_xml and returns a GDBusNodeInfo representing the data.
+        // The introspection XML must contain exactly one top-level <node> element.
+        introspection_data = g_dbus_node_info_new_for_xml(introspection_xml, NULL);
+        g_assert(introspection_data != NULL);
 
-	// Starts acquiring name on the bus (G_BUS_TYPE_SESSION) and calls
-	// name_acquired handler and name_lost when the name is acquired
-	// respectively lost.
-	name_id = g_bus_own_name(G_BUS_TYPE_SESSION,
-				"org.freedesktop.dfuzzerServer",
-				G_BUS_NAME_OWNER_FLAGS_NONE,
-				bus_acquired,
-				name_acquired,
-				name_lost,
-				NULL,
-				NULL);
+        // Starts acquiring name on the bus (G_BUS_TYPE_SESSION) and calls
+        // name_acquired handler and name_lost when the name is acquired
+        // respectively lost.
+        name_id = g_bus_own_name(G_BUS_TYPE_SESSION,
+                                "org.freedesktop.dfuzzerServer",
+                                G_BUS_NAME_OWNER_FLAGS_NONE,
+                                bus_acquired,
+                                name_acquired,
+                                name_lost,
+                                NULL,
+                                NULL);
 
-	g_printf("Name id: %d\n", name_id);
-	loop = g_main_loop_new(NULL, FALSE);
-	g_main_loop_run(loop);
+        g_printf("Name id: %d\n", name_id);
+        loop = g_main_loop_new(NULL, FALSE);
+        g_main_loop_run(loop);
 
-	g_bus_unown_name(name_id);
-	g_dbus_node_info_unref(introspection_data);
-	return 0;
+        g_bus_unown_name(name_id);
+        g_dbus_node_info_unref(introspection_data);
+        return 0;
 }


### PR DESCRIPTION
Also, since the test-server code uses many callback functions with
unused parameters, let's compile just the server with
`-Wno-unused-parameter`, so we don't have to pollute the code with the
`__attribute__((__unused__))` stuff.
