### PR TITLE
fuzz: avoid leaking memory

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -4,10 +4,7 @@ set -ex
 
 dfuzzer=dfuzzer
 if [[ "$TYPE" == valgrind ]]; then
-    # leak-check=full should be brought back once https://github.com/matusmarhefka/dfuzzer/issues/45
-    # is addressed properly. Until then let's use valgrind to make sure uninitizlized memory isn't
-    # used anywhere.
-    dfuzzer='valgrind --leak-check=no --show-leak-kinds=definite --errors-for-leak-kinds=definite --error-exitcode=1 dfuzzer'
+    dfuzzer='valgrind --leak-check=full --show-leak-kinds=definite --errors-for-leak-kinds=definite --error-exitcode=1 dfuzzer'
 fi
 
 $dfuzzer -V

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -571,6 +571,7 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
                 }
                 prev_memory = used_memory;
 
+                value = safe_g_variant_unref(value);
 
                 // creates variant containing all (fuzzed) method arguments
                 value = df_fuzz_create_variant();

--- a/src/util.h
+++ b/src/util.h
@@ -47,6 +47,13 @@ static inline void fclosep(FILE **f) {
         safe_fclose(*f);
 }
 
+static inline GVariant *safe_g_variant_unref(GVariant *p) {
+        if (p)
+                g_variant_unref(p);
+
+        return NULL;
+}
+
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(char*, free, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(gchar*, g_free, NULL);
 DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(GDBusConnection*, g_dbus_connection_unref, NULL);


### PR DESCRIPTION
Let's keep reference only to the last created GVariant, since it's
needed later in the `df_fuzz_write_log()` function.

Resolves: #45

---

Slightly better version of https://github.com/matusmarhefka/dfuzzer/pull/47.

