### PR TITLE
dfuzzer: probe void methods as well

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -2,9 +2,9 @@
 
 set -ex
 
-dfuzzer=dfuzzer
+dfuzzer=("dfuzzer")
 if [[ "$TYPE" == valgrind ]]; then
-    dfuzzer='valgrind --leak-check=full --show-leak-kinds=definite --errors-for-leak-kinds=definite --error-exitcode=42 dfuzzer'
+        dfuzzer=("valgrind" "--leak-check=full" "--show-leak-kinds=definite" "--errors-for-leak-kinds=definite" "--error-exitcode=42" "dfuzzer")
 fi
 
 sudo systemctl daemon-reload
@@ -12,41 +12,41 @@ sudo systemctl start dfuzzer-test-server
 
 set +e
 # https://github.com/matusmarhefka/dfuzzer/issues/45
-$dfuzzer -v -n org.freedesktop.dfuzzerServer
+"${dfuzzer[@]}" -v -n org.freedesktop.dfuzzerServer
 [[ $? == 2 ]] || exit 1
 set -e
 
 sudo systemctl stop dfuzzer-test-server
 
-$dfuzzer -V
-$dfuzzer --version
-$dfuzzer -l
-$dfuzzer -s -l
-$dfuzzer --no-suppressions --list
+"${dfuzzer[@]}" -V
+"${dfuzzer[@]}" --version
+"${dfuzzer[@]}" -l
+"${dfuzzer[@]}" -s -l
+"${dfuzzer[@]}" --no-suppressions --list
 # Test a long suppression file
 perl -e 'print "[org.freedesktop.systemd1]\n"; print "Reboot destructive\n" x 250; print "Reboot\n" x 250' >dfuzzer.conf
-$dfuzzer -v -n org.freedesktop.systemd1 -o /org/freedesktop/systemd1 -i org.freedesktop.systemd1.Manager -t Reboot
+"${dfuzzer[@]}" -v -n org.freedesktop.systemd1 -o /org/freedesktop/systemd1 -i org.freedesktop.systemd1.Manager -t Reboot
 rm -f dfuzzer.conf
 # Check if we probe void methods
 log_out="$(mktemp)"
-sudo $dfuzzer -v -n org.freedesktop.systemd1 -o /org/freedesktop/systemd1 -i org.freedesktop.systemd1.Manager -t ListUnits |& tee "$log_out"
+sudo "${dfuzzer[@]}" -v -n org.freedesktop.systemd1 -o /org/freedesktop/systemd1 -i org.freedesktop.systemd1.Manager -t ListUnits |& tee "$log_out"
 grep "PASS" "$log_out"
 grep "SKIP" "$log_out" && false
 # Test as an unprivileged user (short options)
-$dfuzzer -v -n org.freedesktop.systemd1
+"${dfuzzer[@]}" -v -n org.freedesktop.systemd1
 # Test as root (long options + duplicate options)
-sudo $dfuzzer --verbose --bus this.should.be.ignored --bus org.freedesktop.systemd1
+sudo "${dfuzzer[@]}" --verbose --bus this.should.be.ignored --bus org.freedesktop.systemd1
 # Test logdir
 mkdir dfuzzer-logs
-$dfuzzer --log-dir dfuzzer-logs -v -n org.freedesktop.systemd1
+"${dfuzzer[@]}" --log-dir dfuzzer-logs -v -n org.freedesktop.systemd1
 # Test a non-existent bus
-if sudo $dfuzzer --log-dir "" --bus this.should.not.exist; then false; fi
+if sudo "${dfuzzer[@]}" --log-dir "" --bus this.should.not.exist; then false; fi
 # Test object & interface options
-$dfuzzer -v --bus org.freedesktop.systemd1 --object / --interface org.freedesktop.DBus.Peer
-sudo $dfuzzer -v --bus org.freedesktop.systemd1 --object / --interface org.freedesktop.DBus.Peer
+"${dfuzzer[@]}" -v --bus org.freedesktop.systemd1 --object / --interface org.freedesktop.DBus.Peer
+sudo "${dfuzzer[@]}" -v --bus org.freedesktop.systemd1 --object / --interface org.freedesktop.DBus.Peer
 # - duplicate object/interface paths
-$dfuzzer -v --bus org.freedesktop.systemd1 --object xxx --object yyy --object / --interface org.freedesktop.DBus.Peer
-$dfuzzer -v --bus org.freedesktop.systemd1 --object xxx --object yyy --object / --interface zzz --interface org.freedesktop.DBus.Peer
+"${dfuzzer[@]}" -v --bus org.freedesktop.systemd1 --object xxx --object yyy --object / --interface org.freedesktop.DBus.Peer
+"${dfuzzer[@]}" -v --bus org.freedesktop.systemd1 --object xxx --object yyy --object / --interface zzz --interface org.freedesktop.DBus.Peer
 # - test error paths
-if $dfuzzer -v --bus org.freedesktop.systemd1 --object aaa; then false; fi
-if $dfuzzer -v --bus org.freedesktop.systemd1 --interface aaa; then false; fi
+if "${dfuzzer[@]}" -v --bus org.freedesktop.systemd1 --object aaa; then false; fi
+if "${dfuzzer[@]}" -v --bus org.freedesktop.systemd1 --interface aaa; then false; fi

--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -27,6 +27,11 @@ $dfuzzer --no-suppressions --list
 perl -e 'print "[org.freedesktop.systemd1]\n"; print "Reboot destructive\n" x 250; print "Reboot\n" x 250' >dfuzzer.conf
 $dfuzzer -v -n org.freedesktop.systemd1 -o /org/freedesktop/systemd1 -i org.freedesktop.systemd1.Manager -t Reboot
 rm -f dfuzzer.conf
+# Check if we probe void methods
+log_out="$(mktemp)"
+sudo $dfuzzer -v -n org.freedesktop.systemd1 -o /org/freedesktop/systemd1 -i org.freedesktop.systemd1.Manager -t ListUnits |& tee "$log_out"
+grep "PASS" "$log_out"
+grep "SKIP" "$log_out" && false
 # Test as an unprivileged user (short options)
 $dfuzzer -v -n org.freedesktop.systemd1
 # Test as root (long options + duplicate options)

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -604,14 +604,6 @@ int df_fuzz(GDBusConnection *dcon, const char *name, const char *obj, const char
                         }
                 }
 
-                // methods with no arguments are not tested
-                if (df_list_args_count() == 0) {
-                        df_verbose("%s  %sSKIP%s %s - void method\n",
-                                   ansi_cr(), ansi_blue(), ansi_normal(), m->name);
-                        df_fuzz_clean_method();
-                        continue;
-                }
-
                 if (df_method_has_out_args())
                         void_method = 0;
                 else

--- a/src/dfuzzer.conf
+++ b/src/dfuzzer.conf
@@ -19,16 +19,21 @@ Suspend destructive
 SuspendThenHibernate destructive
 SuspendThenHibernateWithFlags destructive
 SuspendWithFlags destructive
+Terminate destructive
 TerminateSeat destructive
 TerminateSession destructive
 TerminateUser destructive
 
 [org.freedesktop.systemd1]
 Exit destructive
+Freeze destructive
 Halt destructive
 KExec destructive
 PowerOff destructive
 Reboot destructive
+Ref destructive
+Thaw destructive
+Unref destructive
 
 [org.freedesktop.timedate1]
 SetLocalRTC destructive method breaking the RTC and system time

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -528,10 +528,6 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
                 const char *obj, const char *intf, const int pid,
                 const int void_method, const char *execute_cmd)
 {
-        // methods with no arguments are not tested
-        if (df_list.args == 0)
-                return 0;
-
         struct df_signature *s = df_list.list;  // pointer on the first signature
         _cleanup_(g_variant_unrefp) GVariant *value = NULL;
         int ret = 0;            // return value from df_fuzz_call_method()
@@ -561,7 +557,7 @@ int df_fuzz_test_method(const int statfd, long buf_size, const char *name,
 
         df_verbose("  %s...", df_list.df_method_name);
 
-        while (df_rand_continue(df_list.fuzz_on_str_len)) {
+        while (df_rand_continue(df_list.fuzz_on_str_len, df_list.args)) {
                 // parsing proces memory size from its status file described by statfd
                 used_memory = df_fuzz_get_proc_mem_size(statfd);
                 if (used_memory == -1) {

--- a/src/rand.c
+++ b/src/rand.c
@@ -379,9 +379,18 @@ gdouble df_rand_gdouble(void)
  * strings lengths
  * @return 1 when callee should continue, 0 otherwise
  */
-int df_rand_continue(const int fuzz_on_str_len)
+int df_rand_continue(const int fuzz_on_str_len, const int nargs)
 {
         static int counter = 0; // makes sure to test biggest strings more times
+
+       if (nargs == 0) {
+               if (df_num_fuzz_counter == 10) {
+                       df_num_fuzz_counter = 0;
+                       return 0;
+               }
+               df_num_fuzz_counter++;
+               return 1;
+       }
 
         if (fuzz_on_str_len) {
                 if (df_str_len >= df_buf_size) {

--- a/src/rand.h
+++ b/src/rand.h
@@ -103,9 +103,10 @@ gdouble df_rand_gdouble(void);
  * of generated strings not to exceed df_buf_size length.
  * @param fuzz_on_str_len If 1, fuzzing will be controlled by generated random
  * strings lengths
+ * @param nargs Number of arguments of the currently tested method
  * @return 1 when callee should continue, 0 otherwise
  */
-int df_rand_continue(const int fuzz_on_str_len);
+int df_rand_continue(const int fuzz_on_str_len, const int nargs);
 
 /**
  * @function Allocates memory for pseudo-random string of size counted


### PR DESCRIPTION
This is a quick & dirty tweak to see if we can probe void methods
(methods without arguments) as soon as possible, since it proved to be
quite useful.

Resolves: #18