### PR TITLE
dfuzzer: allow specifying a custom set of input strings

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -22,6 +22,19 @@ set -e
 "${dfuzzer[@]}" -s -v -n org.freedesktop.dfuzzerServer -o /org/freedesktop/dfuzzerObject -i org.freedesktop.dfuzzerInterface -t df_complex_sig_1
 "${dfuzzer[@]}" -s -v -n org.freedesktop.dfuzzerServer -o /org/freedesktop/dfuzzerObject -i org.freedesktop.dfuzzerInterface -t df_complex_sig_2
 
+# Crash on a specific string
+"${dfuzzer[@]}" -s -v -n org.freedesktop.dfuzzerServer -o /org/freedesktop/dfuzzerObject -i org.freedesktop.dfuzzerInterface -t df_crash_on_leeroy
+cat >inputs.txt <<'EOF'
+a string
+also a string
+probably a string
+Leeroy Jenkins
+you guessed it - also a string
+no way this is a string as well
+EOF
+"${dfuzzer[@]}" -f inputs.txt -s -v -n org.freedesktop.dfuzzerServer -o /org/freedesktop/dfuzzerObject -i org.freedesktop.dfuzzerInterface -t df_crash_on_leeroy && false
+rm -f inputs.txt
+
 sudo systemctl stop dfuzzer-test-server
 
 # dfuzzer should return 0 by default when services it tests time out

--- a/man/dfuzzer.xml
+++ b/man/dfuzzer.xml
@@ -95,6 +95,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>-f <replaceable>FILENAME</replaceable></option></term>
+                <term><option>--dictionary=<replaceable>FILENAME</replaceable></option></term>
+
+                <listitem><para>Name of a file with custom dictionary whhich is used as input for fuzzed methods
+                before generating random data. Currently supports only strings (one per line).</para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-x <replaceable>ITERATIONS</replaceable></option></term>
                 <term><option>--max-iterations=<replaceable>ITERATIONS</replaceable></option></term>
 

--- a/src/dfuzzer-test-server.c
+++ b/src/dfuzzer-test-server.c
@@ -63,6 +63,9 @@ static const gchar introspection_xml[] =
 "               <method name='df_variant_crash'>"
 "                       <arg type='v' name='variant' direction='in'/>"
 "               </method>"
+"               <method name='df_crash_on_leeroy'>"
+"                       <arg type='s' name='string' direction='in'/>"
+"               </method>"
 "               <method name='df_complex_sig_1'>"
 "                       <arg type='i' name='in1' direction='in'/>"
 "                       <arg type='u' name='in2' direction='in'/>"
@@ -114,7 +117,15 @@ static void handle_method_call(
                 g_printf("Sending response to Client: [%s]\n", response);
         } else if (g_strcmp0(method_name, "df_crash") == 0 || g_strcmp0(method_name, "df_variant_crash") == 0)
                 abort();
-        else if (g_strcmp0(method_name, "df_hang") == 0)
+        else if (g_strcmp0(method_name, "df_crash_on_leeroy") == 0) {
+                gchar *str = NULL;
+
+                g_variant_get(parameters, "(&s)", &str);
+                if (g_strcmp0(str, "Leeroy Jenkins") == 0)
+                        abort();
+
+                g_dbus_method_invocation_return_value(invocation, g_variant_new("()"));
+        } else if (g_strcmp0(method_name, "df_hang") == 0)
                 pause();
         else if (g_strcmp0(method_name, "df_noreply") == 0)
                 return;

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -34,6 +34,7 @@
 #include "dfuzzer.h"
 #include "introspection.h"
 #include "fuzz.h"
+#include "rand.h"
 #include "util.h"
 
 
@@ -779,6 +780,7 @@ void df_parse_parameters(int argc, char **argv)
                 { "buffer-limit",       required_argument,  NULL,   'b' },
                 { "debug",              no_argument,        NULL,   'd' },
                 { "command",            required_argument,  NULL,   'e' },
+                { "string-file",        required_argument,  NULL,   'f' },
                 { "help",               no_argument,        NULL,   'h' },
                 { "interface",          required_argument,  NULL,   'i' },
                 { "list",               no_argument,        NULL,   'l' },
@@ -796,7 +798,7 @@ void df_parse_parameters(int argc, char **argv)
                 {}
         };
 
-        while ((c = getopt_long(argc, argv, "n:o:i:m:b:t:e:L:x:y:I:sdvlhV", options, NULL)) >= 0) {
+        while ((c = getopt_long(argc, argv, "n:o:i:m:b:t:e:L:x:y:f:I:sdvlhV", options, NULL)) >= 0) {
                 switch (c) {
                         case 'n':
                                 if (strlen(optarg) >= MAXLEN) {
@@ -916,6 +918,14 @@ void df_parse_parameters(int argc, char **argv)
                                 }
 
                                 df_max_iterations = df_min_iterations;
+
+                                break;
+                        case 'f':
+                                r = df_rand_load_external_dictionary(optarg);
+                                if (r < 0) {
+                                        df_fail("Error: failed to load dictionary from file '%s'\n", optarg);
+                                        exit(1);
+                                }
 
                                 break;
                         default:    // '?'
@@ -1137,6 +1147,8 @@ void df_print_help(const char *name)
          "  -I --iterations=ITER        Set both the minimum and maximum number of iterations to ITER\n"
          "                              See --max-iterations= and --min-iterations= above\n"
          "  -e --command=COMMAND        Command/script to execute after each method call.\n"
+         "  -f --dictionary=FILENAME    Name of a file with custom dictionary which is used as input\n"
+         "                              for fuzzed methods before generating random data.\n"
          "\nExamples:\n\n"
          "Test all methods of GNOME Shell. Be verbose.\n"
          "# %1$s -v -n org.gnome.Shell\n\n"

--- a/src/rand.h
+++ b/src/rand.h
@@ -34,6 +34,10 @@
 /** Maximum length of D-Bus signature string */
 #define MAXSIG 255
 
+struct external_dictionary {
+        size_t size;
+        char **strings;
+};
 
 /**
  * @function Initializes global flag variables and seeds pseudo-random
@@ -41,6 +45,7 @@
  * @param buf_size Maximum buffer size for generated strings (in Bytes)
  */
 void df_rand_init(const long buf_size);
+int df_rand_load_external_dictionary(const char *filename);
 
 /**
  * @return Generated pseudo-random 8-bit unsigned integer value


### PR DESCRIPTION
@evverx possible solution for https://github.com/systemd/systemd/issues/23312#issuecomment-1120441314.

One downside which comes to mind is that you can't specify strings with newlines, since the newline is used as a separator. If that would be an issue, I'd have to come up with a different solution.