### PR TITLE
fuzz: check the method call return code as well

### DIFF
--- a/src/dfuzzer.conf
+++ b/src/dfuzzer.conf
@@ -25,18 +25,19 @@ TerminateSession destructive
 TerminateUser destructive
 
 [org.freedesktop.systemd1]
-Exit destructive
+org.freedesktop.systemd1.Manager:Exit destructive
+org.freedesktop.systemd1.Manager:FreezeUnit destructive
+org.freedesktop.systemd1.Manager:Halt destructive
+org.freedesktop.systemd1.Manager:KExec destructive
+org.freedesktop.systemd1.Manager:PowerOff destructive
+org.freedesktop.systemd1.Manager:Reboot destructive
+org.freedesktop.systemd1.Manager:Reexecute FIXME: disconnects systemd from the bus
+org.freedesktop.systemd1.Manager:RefUnit destructive
+org.freedesktop.systemd1.Manager:UnrefUnit destructive
 Freeze destructive
-FreezeUnit destructive
-Halt destructive
-KExec destructive
-PowerOff destructive
-Reboot destructive
 Ref destructive
-RefUnit destructive
 Thaw destructive
 Unref destructive
-UnrefUnit destructive
 
 [org.freedesktop.timedate1]
 SetLocalRTC destructive method breaking the RTC and system time

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -482,6 +482,12 @@ int df_fuzz_test_method(
                 ret = df_fuzz_call_method(method, value);
                 execr = df_exec_cmd_check(execute_cmd);
 
+                if (ret < 0) {
+                        df_fail("%s  %sFAIL%s %s - unexpected response\n",
+                                ansi_cr(), ansi_red(), ansi_normal(), method->name);
+                        break;
+                }
+
                 if (execr < 0)
                         return df_fail_ret(-1, "df_exec_cmd_check() failed: %m");
                 else if (execr > 0) {


### PR DESCRIPTION
I'm actually baffled how I managed to miss this, but thanks to sheer
luck the crashes were getting detected, albeit a bit later (when dfuzzer
detected the remote PID disappeared). All this surfaced once I was
trying to dump a reproducer for each specific fail/crash, and was
getting wrong values (i.e. values from a couple of iterations later).

tl;dr we ignored when the method returned no reply or timed out.