### PR TITLE
fuzz: respect the `org.freedesktop.DBus.Method.NoReply` annotation

### DIFF
--- a/src/dfuzzer-test-server.c
+++ b/src/dfuzzer-test-server.c
@@ -60,6 +60,10 @@ static const gchar introspection_xml[] =
 "               <method name='df_noreply'>"
 "                       <arg type='t' name='lol' direction='in'/>"
 "               </method>"
+"               <method name='df_noreply_expected'>"
+"                       <arg type='ag' name='in' direction='in'/>"
+"                       <annotation name='org.freedesktop.DBus.Method.NoReply' value='true'/>"
+"               </method>"
 "               <method name='df_variant_crash'>"
 "                       <arg type='v' name='variant' direction='in'/>"
 "               </method>"
@@ -127,8 +131,8 @@ static void handle_method_call(
                 g_dbus_method_invocation_return_value(invocation, g_variant_new("()"));
         } else if (g_strcmp0(method_name, "df_hang") == 0)
                 pause();
-        else if (g_strcmp0(method_name, "df_noreply") == 0)
-                return;
+        else if (g_strcmp0(method_name, "df_noreply") == 0 || g_strcmp0(method_name, "df_noreply_expected") == 0)
+                g_dbus_method_invocation_return_dbus_error(invocation, "org.freedesktop.DBus.Error.NoReply", "org.freedesktop.DBus.Error.NoReply");
         else if (g_strcmp0(method_name, "df_complex_sig_1") == 0) {
                 gchar *str = NULL;
                 unsigned u;

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -533,6 +533,7 @@ int df_fuzz(GDBusConnection *dcon, const char *name, const char *object, const c
                 dbus_method.name = strdup(m->name);
                 dbus_method.signature = df_method_get_full_signature(m);
                 dbus_method.returns_value = !!*(m->out_args);
+                dbus_method.expect_reply = df_method_returns_reply(m);
                 dbus_method.fuzz_on_str_len = (strstr(dbus_method.signature, "s") || strstr(dbus_method.signature, "v"));
 
                 // tests for method

--- a/src/dfuzzer.conf
+++ b/src/dfuzzer.conf
@@ -31,7 +31,6 @@ org.freedesktop.systemd1.Manager:Halt destructive
 org.freedesktop.systemd1.Manager:KExec destructive
 org.freedesktop.systemd1.Manager:PowerOff destructive
 org.freedesktop.systemd1.Manager:Reboot destructive
-org.freedesktop.systemd1.Manager:Reexecute FIXME: disconnects systemd from the bus
 org.freedesktop.systemd1.Manager:RefUnit destructive
 org.freedesktop.systemd1.Manager:UnrefUnit destructive
 Freeze destructive

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -591,7 +591,9 @@ static int df_fuzz_call_method(const struct df_dbus_method *method, GVariant *va
                 if (dbus_error) {
                         // if process does not respond
                         if (strcmp(dbus_error, "org.freedesktop.DBus.Error.NoReply") == 0)
-                                return -1;
+                                /* If the method is annotated as "NoReply", don't consider
+                                 * not replying as an error */
+                                return method->expect_reply ? -1 : 0;
                         else if (strcmp(dbus_error, "org.freedesktop.DBus.Error.Timeout") == 0) {
                                 sleep(10);      // wait for tested process; processing
                                 // of longer inputs may take a longer time

--- a/src/fuzz.h
+++ b/src/fuzz.h
@@ -32,6 +32,7 @@ struct df_dbus_method {
         char *name;
         char *signature;
         gboolean returns_value;
+        gboolean expect_reply;
 
         int fuzz_on_str_len;
 };

--- a/src/introspection.c
+++ b/src/introspection.c
@@ -102,3 +102,16 @@ char *df_method_get_full_signature(const GDBusMethodInfo *method)
         return r;
 }
 
+gboolean df_method_returns_reply(const GDBusMethodInfo *method)
+{
+        const gchar *annotation_str;
+
+        assert(method);
+
+        annotation_str = g_dbus_annotation_info_lookup(method->annotations,
+                                                       "org.freedesktop.DBus.Method.NoReply");
+        if (!isempty(annotation_str) && g_strcmp0(annotation_str, "true") == 0)
+                return FALSE;
+
+        return TRUE;
+}

--- a/src/introspection.h
+++ b/src/introspection.h
@@ -22,5 +22,6 @@
 
 GDBusNodeInfo *df_get_interface_info(GDBusProxy *dproxy, const char *interface, GDBusInterfaceInfo **ret_iinfo);
 char *df_method_get_full_signature(const GDBusMethodInfo *method);
+gboolean df_method_returns_reply(const GDBusMethodInfo *method);
 
 #endif


### PR DESCRIPTION
So we don't expect a reply from a method which intentionally doesn't
respond.

---

Tested on Rawhide and it seems to DTRT:

```
# dfuzzer -s -v -n org.freedesktop.systemd1 -o /org/freedesktop/systemd1 -i org.freedesktop.systemd1.Manager -t Reexecute
[SESSION BUS]
Bus not found.
[SYSTEM BUS]
[PROCESS: /usr/lib/systemd/systemd]
[CONNECTED TO PID: 1]
Object: /org/freedesktop/systemd1
 Interface: org.freedesktop.systemd1.Manager
  PASS Reexecute
Exit status: 0
```