### PR TITLE
fuzz: distinguish between reading/writing properties in logs

### DIFF
--- a/man/dfuzzer.xml
+++ b/man/dfuzzer.xml
@@ -82,8 +82,31 @@
                 <term><option>--method=<replaceable>NAME</replaceable></option></term>
 
                 <listitem><para>If provided, only method named <replaceable>NAME</replaceable> is tested.
-                Requires <option>-o/--object=</option> and <option>-i/--interface=</option> to be set as well.
-                </para></listitem>
+                Requires <option>-o/--object=</option> and <option>-i/--interface=</option> to be set as well.</para>
+
+                <para>Implies <option>--skip-properties</option>.</para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>-p <replaceable>NAME</replaceable></option></term>
+                <term><option>--property=<replaceable>NAME</replaceable></option></term>
+
+                <listitem><para>If provided, only property named <replaceable>NAME</replaceable> is tested.
+                Requires <option>-o/--object=</option> and <option>-i/--interface=</option> to be set as well.</para>
+
+                <para>Implies <option>--skip-methods</option>.</para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--skip-methods</option></term>
+
+                <listitem><para>Skip method testing and test only properties.</para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--skip-properties</option></term>
+
+                <listitem><para>Skip property testing and test only methods.</para></listitem>
             </varlistentry>
 
             <varlistentry>

--- a/src/dfuzzer-test-server.c
+++ b/src/dfuzzer-test-server.c
@@ -97,6 +97,7 @@ static const gchar introspection_xml[] =
 "               <property name='read_only' type='s' access='read'/>"
 "               <property name='write_only' type='s' access='write'/>"
 "               <property name='crash_on_write' type='i' access='write'/>"
+"               <property name='crash_on_read' type='a(gov)' access='read'/>"
 "               <property name='read_write' type='(iu)' access='readwrite'/>"
 "       </interface>"
 "</node>";
@@ -180,11 +181,12 @@ static GVariant *handle_get_property(
 
         g_printf("->[handle_get_property] %s\n", property_name);
 
-        if (g_str_equal(property_name, "read_only")) {
+        if (g_str_equal(property_name, "read_only"))
                 response = g_variant_new("(s)", prop_read_only);
-        } else if (g_str_equal(property_name, "read_write")) {
+        else if (g_str_equal(property_name, "crash_on_read"))
+                test_abort();
+        else if (g_str_equal(property_name, "read_write"))
                 response = g_variant_new("(iu)", prop_read_write.i, prop_read_write.u);
-        }
 
         return response;
 }


### PR DESCRIPTION
Also, reorder the for/loop statements, because I have no idea why I put
them like I did in the first place, and check if the remote side is
alive even after just reading a property.

```
 Interface: org.freedesktop.dfuzzerInterface
  PASS [P] read_only (read)
  PASS [P] write_only (write)
  FAIL [P] crash_on_write (write) - unexpected response while writing to a property
[RE-CONNECTED TO PID: 2479535]
  PASS [P] read_write (read)
  PASS [P] read_write (write)
  PASS [M] df_hello
...
```

Addresses: https://github.com/matusmarhefka/dfuzzer/pull/86#pullrequestreview-971808731
